### PR TITLE
Allow spaces (and other things) as separators when parsing RFC3339

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,28 +85,28 @@ single-use-lifetimes = "warn"
 trivial-casts = "warn"
 trivial-numeric-casts = "warn"
 unreachable-pub = "warn"
-unstable-name-collisions = { level = "warn", priority = 1 } # overrides #![deny(future_incompatible)]
-unused = "warn"
+unused = { level = "warn", priority = -1 }
 unused-import-braces = "warn"
 unused-lifetimes = "warn"
 unused-qualifications = "warn"
-# unused-results = "warn"
 variant-size-differences = "warn"
+
+unstable-name-collisions = { level = "allow", priority = 1 } # overrides #![deny(future_incompatible)], temporary while `.cast_{un}signed()` is unstable
 
 [workspace.lints.clippy]
 alloc-instead-of-core = "deny"
 std-instead-of-core = "deny"
 undocumented-unsafe-blocks = "deny"
 
-all = "warn"
+missing-docs-in-private-items = "warn"
+all = { level = "warn", priority = -1 }
 dbg-macro = "warn"
 decimal-literal-representation = "warn"
 explicit-auto-deref = "warn"
 get-unwrap = "warn"
 manual-let-else = "warn"
-missing-docs-in-private-items = "warn"
 missing-enforced-import-renames = "warn"
-nursery = "warn"
+nursery = { level = "warn", priority = -1 }
 obfuscated-if-else = "warn"
 print-stdout = "warn"
 semicolon-outside-block = "warn"

--- a/benchmarks/rand.rs
+++ b/benchmarks/rand.rs
@@ -11,7 +11,7 @@ macro_rules! bench_rand {
                 iter_batched_ref!(
                     ben,
                     || StepRng::new(0, 1),
-                    [|rng| rng.gen::<$type>()]
+                    [|rng| rng.r#gen::<$type>()]
                 );
             })*
         }

--- a/tests/duration.rs
+++ b/tests/duration.rs
@@ -1,4 +1,3 @@
-use core::u64;
 use std::cmp::Ordering;
 use std::cmp::Ordering::{Equal, Greater, Less};
 use std::time::Duration as StdDuration;

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -34,7 +34,7 @@ fn run_with_all_features() -> Result<(), Box<dyn std::error::Error>> {
     impl std::error::Error for Error {}
 
     let status = std::process::Command::new("cargo")
-        .args(&["test", "--all-features"])
+        .args(["test", "--all-features"])
         .status()?;
 
     return if status.success() {

--- a/tests/parsing.rs
+++ b/tests/parsing.rs
@@ -323,6 +323,16 @@ fn rfc_3339() -> time::Result<()> {
         offset!(-00:01),
     );
 
+    // Any separator is allowed by RFC 3339, not just `T`.
+    assert_eq!(
+        OffsetDateTime::parse("2021-01-02 03:04:05Z", &Rfc3339)?,
+        datetime!(2021-01-02 03:04:05 UTC),
+    );
+    assert_eq!(
+        OffsetDateTime::parse("2021-01-02$03:04:05Z", &Rfc3339)?,
+        datetime!(2021-01-02 03:04:05 UTC),
+    );
+
     Ok(())
 }
 
@@ -354,8 +364,8 @@ fn rfc_3339_err() {
         invalid_component!("day")
     ));
     assert!(matches!(
-        PrimitiveDateTime::parse("2021-01-01x", &Rfc3339),
-        invalid_literal!()
+        PrimitiveDateTime::parse("2021-01-01", &Rfc3339),
+        invalid_component!("separator")
     ));
     assert!(matches!(
         PrimitiveDateTime::parse("2021-01-01T0", &Rfc3339),
@@ -448,8 +458,8 @@ fn rfc_3339_err() {
         invalid_component!("day")
     ));
     assert!(matches!(
-        OffsetDateTime::parse("2021-01-01x", &Rfc3339),
-        invalid_literal!()
+        OffsetDateTime::parse("2021-01-01", &Rfc3339),
+        invalid_component!("separator")
     ));
     assert!(matches!(
         OffsetDateTime::parse("2021-01-01T0", &Rfc3339),

--- a/tests/rand.rs
+++ b/tests/rand.rs
@@ -7,15 +7,15 @@ fn support() {
     let mut rng = rand::rngs::mock::StepRng::new(0, 656_175_560);
 
     for _ in 0..7 {
-        let _ = rng.gen::<Weekday>();
+        let _ = rng.r#gen::<Weekday>();
     }
     for _ in 0..12 {
-        let _ = rng.gen::<Month>();
+        let _ = rng.r#gen::<Month>();
     }
-    let _ = rng.gen::<Time>();
-    let _ = rng.gen::<Date>();
-    let _ = rng.gen::<UtcOffset>();
-    let _ = rng.gen::<PrimitiveDateTime>();
-    let _ = rng.gen::<OffsetDateTime>();
-    let _ = rng.gen::<Duration>();
+    let _ = rng.r#gen::<Time>();
+    let _ = rng.r#gen::<Date>();
+    let _ = rng.r#gen::<UtcOffset>();
+    let _ = rng.r#gen::<PrimitiveDateTime>();
+    let _ = rng.r#gen::<OffsetDateTime>();
+    let _ = rng.r#gen::<Duration>();
 }

--- a/time/src/duration.rs
+++ b/time/src/duration.rs
@@ -517,7 +517,7 @@ impl Duration {
     /// ```rust
     /// # use time::{Duration, ext::NumericalDuration};
     /// assert_eq!(Duration::seconds_f64(0.5), 0.5.seconds());
-    /// assert_eq!(Duration::seconds_f64(-0.5), -0.5.seconds());
+    /// assert_eq!(Duration::seconds_f64(-0.5), (-0.5).seconds());
     /// ```
     pub fn seconds_f64(seconds: f64) -> Self {
         try_from_secs!(
@@ -564,7 +564,7 @@ impl Duration {
     /// ```rust
     /// # use time::{Duration, ext::NumericalDuration};
     /// assert_eq!(Duration::saturating_seconds_f64(0.5), 0.5.seconds());
-    /// assert_eq!(Duration::saturating_seconds_f64(-0.5), -0.5.seconds());
+    /// assert_eq!(Duration::saturating_seconds_f64(-0.5), (-0.5).seconds());
     /// assert_eq!(
     ///     Duration::saturating_seconds_f64(f64::NAN),
     ///     Duration::new(0, 0),
@@ -637,7 +637,7 @@ impl Duration {
     /// ```rust
     /// # use time::{Duration, ext::NumericalDuration};
     /// assert_eq!(Duration::checked_seconds_f64(0.5), Some(0.5.seconds()));
-    /// assert_eq!(Duration::checked_seconds_f64(-0.5), Some(-0.5.seconds()));
+    /// assert_eq!(Duration::checked_seconds_f64(-0.5), Some((-0.5).seconds()));
     /// assert_eq!(Duration::checked_seconds_f64(f64::NAN), None);
     /// assert_eq!(Duration::checked_seconds_f64(f64::NEG_INFINITY), None);
     /// assert_eq!(Duration::checked_seconds_f64(f64::INFINITY), None);
@@ -664,7 +664,7 @@ impl Duration {
     /// ```rust
     /// # use time::{Duration, ext::NumericalDuration};
     /// assert_eq!(Duration::checked_seconds_f32(0.5), Some(0.5.seconds()));
-    /// assert_eq!(Duration::checked_seconds_f32(-0.5), Some(-0.5.seconds()));
+    /// assert_eq!(Duration::checked_seconds_f32(-0.5), Some((-0.5).seconds()));
     /// assert_eq!(Duration::checked_seconds_f32(f32::NAN), None);
     /// assert_eq!(Duration::checked_seconds_f32(f32::NEG_INFINITY), None);
     /// assert_eq!(Duration::checked_seconds_f32(f32::INFINITY), None);

--- a/time/src/error/component_range.rs
+++ b/time/src/error/component_range.rs
@@ -89,4 +89,5 @@ impl ComponentRange {
 }
 
 #[cfg(feature = "std")]
+#[allow(clippy::std_instead_of_core)]
 impl std::error::Error for ComponentRange {}

--- a/time/src/error/conversion_range.rs
+++ b/time/src/error/conversion_range.rs
@@ -16,6 +16,7 @@ impl fmt::Display for ConversionRange {
 }
 
 #[cfg(feature = "std")]
+#[allow(clippy::std_instead_of_core)]
 impl std::error::Error for ConversionRange {}
 
 impl From<ConversionRange> for crate::Error {

--- a/time/src/error/different_variant.rs
+++ b/time/src/error/different_variant.rs
@@ -14,6 +14,7 @@ impl fmt::Display for DifferentVariant {
 }
 
 #[cfg(feature = "std")]
+#[allow(clippy::std_instead_of_core)]
 impl std::error::Error for DifferentVariant {}
 
 impl From<DifferentVariant> for crate::Error {

--- a/time/src/error/format.rs
+++ b/time/src/error/format.rs
@@ -55,6 +55,7 @@ impl TryFrom<Format> for io::Error {
 }
 
 #[cfg(feature = "std")]
+#[allow(clippy::std_instead_of_core)]
 impl std::error::Error for Format {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match *self {

--- a/time/src/error/indeterminate_offset.rs
+++ b/time/src/error/indeterminate_offset.rs
@@ -15,6 +15,7 @@ impl fmt::Display for IndeterminateOffset {
 }
 
 #[cfg(feature = "std")]
+#[allow(clippy::std_instead_of_core)]
 impl std::error::Error for IndeterminateOffset {}
 
 impl From<IndeterminateOffset> for crate::Error {

--- a/time/src/error/invalid_format_description.rs
+++ b/time/src/error/invalid_format_description.rs
@@ -125,4 +125,5 @@ impl fmt::Display for InvalidFormatDescription {
 }
 
 #[cfg(feature = "std")]
+#[allow(clippy::std_instead_of_core)]
 impl std::error::Error for InvalidFormatDescription {}

--- a/time/src/error/invalid_variant.rs
+++ b/time/src/error/invalid_variant.rs
@@ -14,6 +14,7 @@ impl fmt::Display for InvalidVariant {
 }
 
 #[cfg(feature = "std")]
+#[allow(clippy::std_instead_of_core)]
 impl std::error::Error for InvalidVariant {}
 
 impl From<InvalidVariant> for crate::Error {

--- a/time/src/error/mod.rs
+++ b/time/src/error/mod.rs
@@ -105,6 +105,7 @@ impl fmt::Display for Error {
 }
 
 #[cfg(feature = "std")]
+#[allow(clippy::std_instead_of_core)]
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {

--- a/time/src/error/parse.rs
+++ b/time/src/error/parse.rs
@@ -35,6 +35,7 @@ impl fmt::Display for Parse {
 }
 
 #[cfg(feature = "std")]
+#[allow(clippy::std_instead_of_core)]
 impl std::error::Error for Parse {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {

--- a/time/src/error/parse_from_description.rs
+++ b/time/src/error/parse_from_description.rs
@@ -33,6 +33,7 @@ impl fmt::Display for ParseFromDescription {
 }
 
 #[cfg(feature = "std")]
+#[allow(clippy::std_instead_of_core)]
 impl std::error::Error for ParseFromDescription {}
 
 impl From<ParseFromDescription> for crate::Error {

--- a/time/src/error/try_from_parsed.rs
+++ b/time/src/error/try_from_parsed.rs
@@ -44,6 +44,7 @@ impl TryFrom<TryFromParsed> for error::ComponentRange {
 }
 
 #[cfg(feature = "std")]
+#[allow(clippy::std_instead_of_core)]
 impl std::error::Error for TryFromParsed {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {

--- a/time/src/parsing/mod.rs
+++ b/time/src/parsing/mod.rs
@@ -35,7 +35,7 @@ impl<'a, T> ParsedItem<'a, T> {
     /// Filter the value with the provided function. If the function returns `false`, the value
     /// is discarded and `None` is returned. Otherwise, the value is preserved and `Some(self)` is
     /// returned.
-    pub(crate) fn filter(self, f: impl FnOnce(&T) -> bool) -> Option<ParsedItem<'a, T>> {
+    pub(crate) fn filter(self, f: impl FnOnce(&T) -> bool) -> Option<Self> {
         f(&self.1).then_some(self)
     }
 }

--- a/time/src/parsing/parsable.rs
+++ b/time/src/parsing/parsable.rs
@@ -520,9 +520,18 @@ impl sealed::Sealed for Rfc3339 {
         let input = exactly_n_digits::<2, _>(input)
             .and_then(|item| item.consume_value(|value| parsed.set_day(value)))
             .ok_or(InvalidComponent("day"))?;
-        let input = ascii_char_ignore_case::<b'T'>(input)
-            .ok_or(InvalidLiteral)?
-            .into_inner();
+
+        // RFC3339 allows any separator, not just `T`, not just `space`.
+        // cf. Section 5.6: Internet Date/Time Format:
+        //   NOTE: ISO 8601 defines date and time separated by "T".
+        //   Applications using this syntax may choose, for the sake of
+        //   readability, to specify a full-date and full-time separated by
+        //   (say) a space character.
+        // Specifically, rusqlite uses space separators.
+        let input = input
+            .get(1..)
+            .ok_or_else(|| InvalidComponent("separator"))?;
+
         let input = exactly_n_digits::<2, _>(input)
             .and_then(|item| item.consume_value(|value| parsed.set_hour_24(value)))
             .ok_or(InvalidComponent("hour"))?;
@@ -618,9 +627,18 @@ impl sealed::Sealed for Rfc3339 {
         let input = dash(input).ok_or(InvalidLiteral)?.into_inner();
         let ParsedItem(input, day) =
             exactly_n_digits::<2, _>(input).ok_or(InvalidComponent("day"))?;
-        let input = ascii_char_ignore_case::<b'T'>(input)
-            .ok_or(InvalidLiteral)?
-            .into_inner();
+
+        // RFC3339 allows any separator, not just `T`, not just `space`.
+        // cf. Section 5.6: Internet Date/Time Format:
+        //   NOTE: ISO 8601 defines date and time separated by "T".
+        //   Applications using this syntax may choose, for the sake of
+        //   readability, to specify a full-date and full-time separated by
+        //   (say) a space character.
+        // Specifically, rusqlite uses space separators.
+        let input = input
+            .get(1..)
+            .ok_or_else(|| InvalidComponent("separator"))?;
+
         let ParsedItem(input, hour) =
             exactly_n_digits::<2, _>(input).ok_or(InvalidComponent("hour"))?;
         let input = colon(input).ok_or(InvalidLiteral)?.into_inner();

--- a/time/src/rand.rs
+++ b/time/src/rand.rs
@@ -7,7 +7,7 @@ use crate::{Date, Duration, Month, OffsetDateTime, PrimitiveDateTime, Time, UtcO
 
 impl Distribution<Time> for Standard {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Time {
-        Time::from_hms_nanos_ranged(rng.gen(), rng.gen(), rng.gen(), rng.gen())
+        Time::from_hms_nanos_ranged(rng.r#gen(), rng.r#gen(), rng.r#gen(), rng.r#gen())
     }
 }
 
@@ -21,7 +21,7 @@ impl Distribution<Date> for Standard {
 
 impl Distribution<UtcOffset> for Standard {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> UtcOffset {
-        UtcOffset::from_hms_ranged(rng.gen(), rng.gen(), rng.gen())
+        UtcOffset::from_hms_ranged(rng.r#gen(), rng.r#gen(), rng.r#gen())
     }
 }
 
@@ -40,7 +40,7 @@ impl Distribution<OffsetDateTime> for Standard {
 
 impl Distribution<Duration> for Standard {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Duration {
-        Duration::new_ranged(rng.gen(), rng.gen())
+        Duration::new_ranged(rng.r#gen(), rng.r#gen())
     }
 }
 

--- a/time/src/serde/mod.rs
+++ b/time/src/serde/mod.rs
@@ -172,9 +172,11 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 /// use time::serde;
 /// use time::format_description::well_known::{iso8601, Iso8601};
 ///
+/// # #[allow(dead_code)]
 /// const CONFIG: iso8601::EncodedConfig = iso8601::Config::DEFAULT
 ///     .set_year_is_six_digits(false)
 ///     .encode();
+/// # #[allow(dead_code)]
 /// const FORMAT: Iso8601<CONFIG> = Iso8601::<CONFIG>;
 ///
 /// // Makes a module `mod my_format { ... }`.


### PR DESCRIPTION
cf. https://hachyderm.io/@fasterthanlime/112834567377457088